### PR TITLE
Fix/correct formula for new_ivl in disperse_siblings

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,5 +5,6 @@
     "auto_reschedule_after_sync": false,
     "auto_reschedule_after_review": false,
     "auto_disperse": true,
-    "mature_ivl": 21
+    "mature_ivl": 21,
+    "debug_notify": false
 }

--- a/configuration.py
+++ b/configuration.py
@@ -10,6 +10,7 @@ AUTO_RESCHEDULE_AFTER_SYNC = "auto_reschedule_after_sync"
 AUTO_RESCHEDULE_AFTER_REVIEW = "auto_reschedule_after_review"
 AUTO_DISPERSE = "auto_disperse"
 MATURE_IVL = "mature_ivl"
+DEBUG_NOTIFY = "debug_notify"
 
 
 def load_config():
@@ -97,4 +98,13 @@ class Config:
     @mature_ivl.setter
     def mature_ivl(self, value):
         self.data[MATURE_IVL] = value
+        self.save()
+
+    @property
+    def debug_notify(self):
+        return self.data[DEBUG_NOTIFY]
+
+    @debug_notify.setter
+    def debug_notify(self, value):
+        self.data[DEBUG_NOTIFY] = value
         self.save()

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -300,14 +300,14 @@ def disperse_siblings_when_review(reviewer, card: Card, ease, undo_entry=None):
     if len(siblings) <= 1:
         return
     
-    # messages = []
+    messages = []
     
     card_cnt = 0
     undo_entry = mw.col.add_custom_undo_entry("Disperse") if undo_entry is None else undo_entry
     best_due_dates = disperse(siblings)
     for cid, due in best_due_dates.items():
         card = mw.col.get_card(cid)
-        # old_due = card.odue if card.odid else card.due
+        old_due = card.odue if card.odid else card.due
         last_revlog = mw.col.card_stats_data(cid).revlog[0]
         last_due = get_last_review_date(last_revlog)
         card = update_card_due_ivl(card, last_revlog, due - last_due)
@@ -317,7 +317,8 @@ def disperse_siblings_when_review(reviewer, card: Card, ease, undo_entry=None):
         mw.col.update_card(card)
         mw.col.merge_undo_entries(undo_entry)
         card_cnt += 1
-            # message = f"Dispersed card {html_to_text_line(card.question())} from {due_to_date(old_due)} to {due_to_date(due)}"
-            # messages.append(message)
-    # tooltip(f"Dispersed {card_cnt} cards")
-    # showText("\n".join(messages))
+        message = f"Dispersed card {card.id} from {due_to_date(old_due)} to {due_to_date(due)}"
+        messages.append(message)
+
+    if config.debug_notify:
+        tooltip("<br/>".join(messages))

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -47,13 +47,13 @@ def get_due_range(cid, parameters, stability, due):
     revlogs = filter_revlogs(mw.col.card_stats_data(cid).revlog)
     last_due = get_last_review_date(revlogs[0])
     last_rating = revlogs[0].button_chosen
-    if version[0] == 3:
-        if last_rating == 4:
+    if version[0] == 4:
+        new_ivl = int(round(9 * stability * (1 / parameters['r'] - 1)))
+    else:
+         if last_rating == 4:
             new_ivl = int(round(stability * parameters['e'] * math.log(parameters['r']) / math.log(0.9)))
         else:
-            new_ivl = int(round(stability * math.log(parameters['r']) / math.log(0.9)))
-    else:
-        new_ivl = int(round(9 * stability * (1 / parameters['r'] - 1)))          
+            new_ivl = int(round(stability * math.log(parameters['r']) / math.log(0.9)))        
 
     new_ivl = min(new_ivl, parameters['m'])
 

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -47,13 +47,13 @@ def get_due_range(cid, parameters, stability, due):
     revlogs = filter_revlogs(mw.col.card_stats_data(cid).revlog)
     last_due = get_last_review_date(revlogs[0])
     last_rating = revlogs[0].button_chosen
-    if last_rating == 4:
-        try:
+    if version[0] == 3:
+        if last_rating == 4:
             new_ivl = int(round(stability * parameters['e'] * math.log(parameters['r']) / math.log(0.9)))
-        except KeyError:
-            new_ivl = int(round(9 * stability * (1 / parameters['r'] - 1)))
+        else:
+            new_ivl = int(round(stability * math.log(parameters['r']) / math.log(0.9)))
     else:
-        new_ivl = int(round(stability * math.log(parameters['r']) / math.log(0.9)))
+        new_ivl = int(round(9 * stability * (1 / parameters['r'] - 1)))          
 
     new_ivl = min(new_ivl, parameters['m'])
 

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -46,10 +46,11 @@ def get_siblings(did=None, filter_flag=False, filtered_nid_string=""):
 def get_due_range(cid, parameters, stability, due):
     revlogs = filter_revlogs(mw.col.card_stats_data(cid).revlog)
     last_due = get_last_review_date(revlogs[0])
-    last_rating = revlogs[0].button_chosen
+    version = get_version(custom_scheduler)
     if version[0] == 4:
         new_ivl = int(round(9 * stability * (1 / parameters['r'] - 1)))
     else:
+        last_rating = revlogs[0].button_chosen
         if last_rating == 4:
             new_ivl = int(round(stability * parameters['e'] * math.log(parameters['r']) / math.log(0.9)))
         else:

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -46,6 +46,8 @@ def get_siblings(did=None, filter_flag=False, filtered_nid_string=""):
 def get_due_range(cid, parameters, stability, due):
     revlogs = filter_revlogs(mw.col.card_stats_data(cid).revlog)
     last_due = get_last_review_date(revlogs[0])
+    custom_scheduler = check_fsrs4anki(mw.col.all_config())
+    if custom_scheduler is None: return
     version = get_version(custom_scheduler)
     if version[0] == 4:
         new_ivl = int(round(9 * stability * (1 / parameters['r'] - 1)))

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -50,7 +50,7 @@ def get_due_range(cid, parameters, stability, due):
     if version[0] == 4:
         new_ivl = int(round(9 * stability * (1 / parameters['r'] - 1)))
     else:
-         if last_rating == 4:
+        if last_rating == 4:
             new_ivl = int(round(stability * parameters['e'] * math.log(parameters['r']) / math.log(0.9)))
         else:
             new_ivl = int(round(stability * math.log(parameters['r']) / math.log(0.9)))        

--- a/stats.py
+++ b/stats.py
@@ -231,7 +231,7 @@ def get_true_retention(self):
             td.trc { border: 1px solid; text-align: center; padding: 5px }
             span.young { color: #77cc77 }
             span.mature { color: #00aa00 }
-            span.yam { color: #55aa55 }
+            span.total { color: #55aa55 }
             span.relearn { color: #c35617 }
         </style>
         <br /><br />
@@ -244,7 +244,7 @@ def get_true_retention(self):
             <tr>
                 <td class="trc" colspan=3><span class="young"><b>Young</b></span></td>
                 <td class="trc" colspan=3><span class="mature"><b>Mature</b></span></td>
-                <td class="trc" colspan=3><span class="yam"><b>Young and Mature</b></span></td>
+                <td class="trc" colspan=3><span class="total"><b>Total</b></span></td>
                 <td class="trc" rowspan=2><span class="young"><b>Learned</b></span></td>
                 <td class="trc" rowspan=2><span class="relearn"><b>Relearned</b></span></td>
             </tr>
@@ -255,9 +255,9 @@ def get_true_retention(self):
                 <td class="trc"><span class="mature">Pass</span></td>
                 <td class="trc"><span class="mature">Fail</span></td>
                 <td class="trc"><span class="mature">Retention</span></td>
-                <td class="trc"><span class="yam">Pass</span></td>
-                <td class="trc"><span class="yam">Fail</span></td>
-                <td class="trc"><span class="yam">Retention</span></td>
+                <td class="trc"><span class="total">Pass</span></td>
+                <td class="trc"><span class="total">Fail</span></td>
+                <td class="trc"><span class="total">Retention</span></td>
             </tr>"""
     true_retention_part += stats_row("Day", pastDay)
     true_retention_part += stats_row("Yesterday", pastYesterday)
@@ -308,9 +308,9 @@ def stats_row(name, values):
             <td class="trr"><span class="mature">""" + str(values[3]) + u"""</span></td>
             <td class="trr"><span class="mature">""" + str(values[4]) + u"""</span></td>
             <td class="trr"><span class="mature">""" + values[5] + u"""</span></td>
-            <td class="trr"><span class="yam">""" + str(values[6]) + u"""</span></td>
-            <td class="trr"><span class="yam">""" + str(values[7]) + u"""</span></td>
-            <td class="trr"><span class="yam">""" + values[8] + u"""</span></td>
+            <td class="trr"><span class="total">""" + str(values[6]) + u"""</span></td>
+            <td class="trr"><span class="total">""" + str(values[7]) + u"""</span></td>
+            <td class="trr"><span class="total">""" + values[8] + u"""</span></td>
             <td class="trr"><span class="young">""" + str(values[9]) + u"""</span></td>
             <td class="trr"><span class="relearn">""" + str(values[10]) + u"""</span></td>
         </tr>"""


### PR DESCRIPTION
In the following code, an incorrect formula for `new_ivl` would be used if the user didn't remove the value of `easy bonus` from their scheduler code after updating to v4.
https://github.com/open-spaced-repetition/fsrs4anki-helper/blob/857cba9a70adf62473c07ebc7b8f17f7d416facb/schedule/disperse_siblings.py#L49-L54

I fixed this in the current PR. However, I am not very sure about the correctness of the syntax of the code. So, please verify.

Also, in the above code, the `new_ivl` was calculated using the old formula in v4 when last rating ≠ 4. I have corrected this too.