### PR TITLE
Define mature cards

### DIFF
--- a/stats.py
+++ b/stats.py
@@ -363,7 +363,9 @@ def get_true_retention(self):
     true_retention_part += stats_row("Week", pastWeek)
     true_retention_part += stats_row(pname, pastPeriod)
     true_retention_part += "</table>"
-    true_retention_part += "<p>By default, mature cards are defined as the cards with an interval of 21 days or longer. This cutoff can be adjusted in the add-on config. The current value is %(i)d days.</p>"
+    config = Config()
+    config.load()
+    true_retention_part += f"<p>By default, mature cards are defined as the cards with an interval of 21 days or longer. This cutoff can be adjusted in the add-on config. The current value is {config.mature_ivl} days.</p>"
     return self._section(true_retention_part)
 
 

--- a/stats.py
+++ b/stats.py
@@ -363,6 +363,7 @@ def get_true_retention(self):
     true_retention_part += stats_row("Week", pastWeek)
     true_retention_part += stats_row(pname, pastPeriod)
     true_retention_part += "</table>"
+    true_retention_part += "<p>By default, mature cards are defined as the cards with an interval of 21 days or longer. This cutoff can be adjusted in the add-on config. The current value is %(i)d days.</p>"
     return self._section(true_retention_part)
 
 


### PR DESCRIPTION
Related: https://github.com/open-spaced-repetition/fsrs4anki/issues/351#issuecomment-1685337405

<img width="564" alt="image" src="https://github.com/open-spaced-repetition/fsrs4anki-helper/assets/92206575/6fd6bc8a-3ee3-4a9d-8527-5b13d4e3f0d2">

Just replace %(i)d with the actual value from the config. I tried but couldn't figure out how to do it.
