### PR TITLE
Retention graph by Card Maturity

### DIFF
--- a/stats.py
+++ b/stats.py
@@ -198,6 +198,9 @@ def get_retention_graph(self: CollectionStats):
 
     rate_data_young, _, rate_data_mature, _, cnt_data, _ = data
 
+    recall_min = min(min(item[1], item[2]) for item in offset_retention_review_cnt)
+    recall_max = max(max(item[1], item[2]) for item in offset_retention_review_cnt)
+
     rate_data_young["lines"] = {"show": True}
     rate_data_young["bars"] = {"show": False}
     rate_data_young["yaxis"] = 1
@@ -218,8 +221,8 @@ def get_retention_graph(self: CollectionStats):
         xaxis=dict(tickDecimals=0, max=0.5),
         yaxes=[
             dict(
-                min=0,
-                max=1,
+                min=recall_min,
+                max=recall_max,
                 ticks=[[x / 10, str(round(x / 10, 1))] for x in range(0, 11)],
             ),
             dict(position="right", min=0),

--- a/stats.py
+++ b/stats.py
@@ -172,8 +172,8 @@ def get_retention_graph(self: CollectionStats):
 
     query = f"""SELECT
     CAST((id/1000.0 - {mw.col.sched.day_cutoff}) / 86400.0 as int)/{chunk} AS day,
-    SUM(CASE WHEN ease == 1 AND lastIvl < 21 THEN 0.0 ELSE 1.0 END) / COUNT(*) AS retention_young,
-    SUM(CASE WHEN ease == 1 AND lastIvl >= 21 THEN 0.0 ELSE 1.0 END) / COUNT(*) AS retention_mature,
+    COUNT(CASE WHEN ease > 1 AND lastIvl < 21 THEN cid ELSE NULL END) / COUNT(CASE WHEN lastIvl < 21 THEN cid ELSE NULL END) AS retention_young,
+    COUNT(CASE WHEN ease > 1 AND lastIvl >= 21 THEN cid ELSE NULL END) / COUNT(CASE WHEN lastIvl >= 21 THEN cid ELSE NULL END) AS retention_mature,
     COUNT(*) AS review_cnt
     FROM revlog
     WHERE (type = 1 OR lastIvl <= -86400 OR lastIvl >= 1)

--- a/stats.py
+++ b/stats.py
@@ -200,8 +200,8 @@ def get_retention_graph(self: CollectionStats):
 
     tmp = -2
     new_data = []
-    for item in filter(lambda x: x['label'] is not None, data):
-        if item['label'].startswith("Retention"):
+    for item in filter(lambda x: x["label"] is not None, data):
+        if item["label"].startswith("Retention"):
             item["lines"] = {"show": True}
             item["bars"] = {"show": False}
             item["yaxis"] = 2
@@ -221,15 +221,21 @@ def get_retention_graph(self: CollectionStats):
     recall_max = max(max(item[1], item[2]) for item in offset_retention_review_cnt)
     recall_max = math.ceil(recall_max * 10) / 10
 
+    step = round((recall_max - recall_min) / 5, 2)
+    ticks = [
+        [recall_min + step * i, str(round(recall_min + step * i, 2))]
+        for i in range(0, 6)
+    ]
+
     conf = dict(
         xaxis=dict(tickDecimals=0, max=0.5),
         yaxes=[
             dict(position="left", min=0),
             dict(
-                position="right", 
+                position="right",
                 min=recall_min,
                 max=recall_max,
-                ticks=[[x / 10, str(round(x / 10, 1))] for x in range(0, 11)],
+                ticks=ticks,
             ),
         ],
     )

--- a/stats.py
+++ b/stats.py
@@ -189,7 +189,7 @@ def get_retention_graph(self: CollectionStats):
         (
             (1, "#070", "Retention Rate (young)"),
             (2, "#707", "Retention Rate (mature)"),
-            (3, "#00F", "Review Cnt"),
+            (3, "#00F", "Review Count"),
         ),
     )
 

--- a/stats.py
+++ b/stats.py
@@ -199,33 +199,37 @@ def get_retention_graph(self: CollectionStats):
     rate_data_young, _, rate_data_mature, _, cnt_data, _ = data
 
     recall_min = min(min(item[1], item[2]) for item in offset_retention_review_cnt)
+    recall_min = math.floor(recall_min * 10) / 10
     recall_max = max(max(item[1], item[2]) for item in offset_retention_review_cnt)
-
-    rate_data_young["lines"] = {"show": True}
-    rate_data_young["bars"] = {"show": False}
-    rate_data_young["yaxis"] = 1
-    rate_data_young["stack"] = -1
-
-    rate_data_mature["lines"] = {"show": True}
-    rate_data_mature["bars"] = {"show": False}
-    rate_data_mature["stack"] = -2
+    recall_max = math.ceil(recall_max * 10) / 10
 
     cnt_data["lines"] = {"show": False}
     cnt_data["bars"] = {"show": True}
-    cnt_data["yaxis"] = 2
+    cnt_data["yaxis"] = 1
+    rate_data_mature["stack"] = -1
+
+    rate_data_young["lines"] = {"show": True}
+    rate_data_young["bars"] = {"show": False}
+    rate_data_young["yaxis"] = 2
+    rate_data_young["stack"] = -2
+
+    rate_data_mature["lines"] = {"show": True}
+    rate_data_mature["bars"] = {"show": False}
+    rate_data_mature["yaxis"] = 2
     rate_data_mature["stack"] = -3
 
-    data = [rate_data_young, rate_data_mature, cnt_data]
+    data = [cnt_data, rate_data_young, rate_data_mature]
 
     conf = dict(
         xaxis=dict(tickDecimals=0, max=0.5),
         yaxes=[
+            dict(position="left", min=0),
             dict(
+                position="right", 
                 min=recall_min,
                 max=recall_max,
                 ticks=[[x / 10, str(round(x / 10, 1))] for x in range(0, 11)],
             ),
-            dict(position="right", min=0),
         ],
     )
     if days is not None:
@@ -237,7 +241,7 @@ def get_retention_graph(self: CollectionStats):
         )
 
     txt1 = self._title("Retention Graph", "Retention rate and review count over time")
-    txt1 += plot("retention", data, ylabel="Retention Rate", ylabel2="Review Count")
+    txt1 += plot("retention", data, ylabel="Review Count", ylabel2="Retention Rate")
     return self._section(txt1)
 
 

--- a/stats.py
+++ b/stats.py
@@ -1,4 +1,4 @@
-import anki.stats
+from anki.stats import CollectionStats
 from .configuration import Config
 from .utils import *
 
@@ -96,7 +96,7 @@ def todayStats_new(self):
     )
 
 
-def get_fsrs_stats(self):
+def get_fsrs_stats(self: CollectionStats):
     lim = self._limit()
     if lim:
         lim = " AND did IN %s" % lim
@@ -132,7 +132,7 @@ def get_fsrs_stats(self):
         "Estimated total knowledge",
         f"{round(estimated_total_knowledge_notes)} notes ({(estimated_total_knowledge_notes / max(note_cnt, 1)) * 100:.2f}%)",
     )
-    title = anki.stats.CollectionStats._title(
+    title = CollectionStats._title(
         self,
         "FSRS Stats",
         "Only calculated for cards with custom data (affected by FSRS)",
@@ -157,7 +157,7 @@ def get_fsrs_stats(self):
     )
 
 
-def get_retention_graph(self):
+def get_retention_graph(self: CollectionStats):
     start, days, chunk = self.get_start_end_chunk()
     lims = []
     if days is not None:
@@ -199,17 +199,18 @@ def get_retention_graph(self):
     rate_data_young["lines"] = {"show": True}
     rate_data_young["bars"] = {"show": False}
     rate_data_young["yaxis"] = 1
+    rate_data_young["stack"] = -1
 
     rate_data_mature["lines"] = {"show": True}
     rate_data_mature["bars"] = {"show": False}
-    rate_data_mature["yaxis"] = 1
+    rate_data_mature["stack"] = -2
 
     cnt_data["lines"] = {"show": False}
     cnt_data["bars"] = {"show": True}
     cnt_data["yaxis"] = 2
+    rate_data_mature["stack"] = -3
 
     data = [rate_data_young, rate_data_mature, cnt_data]
-    print(data)
 
     conf = dict(
         xaxis=dict(tickDecimals=0, max=0.5),
@@ -293,10 +294,10 @@ def init_stats():
     config.load()
     if config.fsrs_stats:
         global todayStats_old, cardGraph_old
-        todayStats_old = anki.stats.CollectionStats.todayStats
-        cardGraph_old = anki.stats.CollectionStats.cardGraph
-        anki.stats.CollectionStats.todayStats = todayStats_new
-        anki.stats.CollectionStats.cardGraph = difficulty_distribution_graph
+        todayStats_old = CollectionStats.todayStats
+        cardGraph_old = CollectionStats.cardGraph
+        CollectionStats.todayStats = todayStats_new
+        CollectionStats.cardGraph = difficulty_distribution_graph
 
 
 # code modified from https://ankiweb.net/shared/info/1779060522
@@ -339,7 +340,7 @@ def get_true_retention(self):
         period = 10000
         pname = "Deck life"
     pastPeriod = stats_list(lim, (mw.col.sched.day_cutoff - 86400 * period) * 1000)
-    true_retention_part = anki.stats.CollectionStats._title(
+    true_retention_part = CollectionStats._title(
         self,
         "True Retention",
         "<p>The True Retention is the pass rate calculated only on cards with intervals greater than or equal to one day. It is a better indicator of the learning quality than the Again rate.</p>",

--- a/stats.py
+++ b/stats.py
@@ -188,10 +188,10 @@ def get_retention_graph(self: CollectionStats):
     data, _ = self._splitRepData(
         offset_retention_review_cnt,
         (
-            (1, "#7c7", "Retention Rate (young)"),
-            (2, "#070", "Retention Rate (mature)"),
             (3, "#7c7", "Review Count (young)"),
             (4, "#070", "Review Count (mature)"),
+            (1, "#7c7", "Retention Rate (young)"),
+            (2, "#070", "Retention Rate (mature)"),
         ),
     )
 


### PR DESCRIPTION
The retention graph in the FSRS Stats can be misleading because it doesn't separate low stability and high stability reviews.

For many users, SM-2 tends to show low interval reviews at an unnecessarily high frequency causing the retention to go up. If the retention for the young and mature cards is not separated, this effect can mask the low retention in the high interval reviews.

So, it makes sense to separate young and mature cards in the retention graph.

The True Retention table fixes this to some extent, but it shows the cumulative retention of all the reviews till today and not the retention at a particular point of time. So, it is somewhat difficult to interpret.

Retention graph using current version of the add-on:
<img width="503" alt="image" src="https://github.com/open-spaced-repetition/fsrs4anki-helper/assets/92206575/ade22298-082c-4c2d-8045-926a512d6d65">

Retention graph after my changes (currently bugged):
<img width="504" alt="image" src="https://github.com/open-spaced-repetition/fsrs4anki-helper/assets/92206575/25687220-9697-4620-b946-eb2186e7ac1e">

Although it is not showing the curve for Mature cards, but you can see that the retention in the Young cards is clearly more than the total retention.

I have more improvements to make. But, firstly I need some help in getting the curve for mature cards displayed.