### PR TITLE
Fix/has no attribute 'fuzz factor'

### DIFF
--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -486,7 +486,7 @@ def reschedule_card(cid, fsrs: FSRS, rollover, params):
         new_custom_data["seed"] = fsrs.set_fuzz_factor(cid, card.reps)
     fsrs.fuzz_factor = new_custom_data["seed"] / 10000
     card.custom_data = json.dumps(new_custom_data)
-    
+
     if card.type == CARD_TYPE_REV and last_kind != REVLOG_RESCHED:
         fsrs.set_card(card)
         if last_s is None:

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -479,14 +479,14 @@ def reschedule_card(cid, fsrs: FSRS, rollover, params):
 
     new_custom_data = {"s": round(s, 2), "d": round(d, 2), "v": "reschedule"}
     card = mw.col.get_card(cid)
-    if card.custom_data != "":
-        old_custom_data = json.loads(card.custom_data)
-        if "seed" in old_custom_data:
-            fsrs.fuzz_factor = old_custom_data["seed"] / 10000
-            new_custom_data["seed"] = old_custom_data["seed"]
-        else:
-            new_custom_data["seed"] = fsrs.set_fuzz_factor(cid, reps)
+    old_custom_data = json.loads(card.custom_data)
+    if card.custom_data != "" and "seed" in old_custom_data:
+        new_custom_data["seed"] = old_custom_data["seed"]
+    else:
+        new_custom_data["seed"] = fsrs.set_fuzz_factor(cid, card.reps)
+    fsrs.fuzz_factor = new_custom_data["seed"] / 10000
     card.custom_data = json.dumps(new_custom_data)
+    
     if card.type == CARD_TYPE_REV and last_kind != REVLOG_RESCHED:
         fsrs.set_card(card)
         if last_s is None:

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -479,8 +479,8 @@ def reschedule_card(cid, fsrs: FSRS, rollover, params):
 
     new_custom_data = {"s": round(s, 2), "d": round(d, 2), "v": "reschedule"}
     card = mw.col.get_card(cid)
-    old_custom_data = json.loads(card.custom_data)
-    if card.custom_data != "" and "seed" in old_custom_data:
+    old_custom_data = json.loads(card.custom_data) if card.custom_data != "" else ""
+    if "seed" in old_custom_data:
         new_custom_data["seed"] = old_custom_data["seed"]
     else:
         new_custom_data["seed"] = fsrs.set_fuzz_factor(cid, card.reps)


### PR DESCRIPTION
@L-M-Sherlock, your fix in https://github.com/open-spaced-repetition/fsrs4anki-helper/commit/e64371ce344215fb42502a53988f596cd537962b helped me to locate the problem and work out a possibly better fix.

My version ensures that set_fuzz_factor is not called when the seed is already there in the old custom data. It saves 4 seconds on my collection when rescheduling (25 s vs 21 s).