### PR TITLE
+1 for due when min_due = 0 in disperse siblings

### DIFF
--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -130,11 +130,6 @@ def disperse(siblings):
     due_ranges[-1] = (latest_review, latest_review)
     min_gap, best_due_dates = maximize_siblings_due_gap(due_ranges)
     best_due_dates.pop(-1)
-    
-    if min_gap == 0:
-        for due in best_due_dates.items():
-            due = max(due, mw.col.sched.today + 1) 
-
     return best_due_dates, due_ranges, min_gap
 
 
@@ -232,6 +227,11 @@ def disperse_siblings_when_review(reviewer, card: Card, ease):
     card_cnt = 0
     undo_entry = mw.col.undo_status().last_step
     best_due_dates, due_ranges, min_gap = disperse(siblings)
+
+    if min_gap == 0:
+        for due in best_due_dates.items():
+            due = max(due, mw.col.sched.today + 1)
+    
     for cid, due in best_due_dates.items():
         card = mw.col.get_card(cid)
         old_due = card.odue if card.odid else card.due

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -133,8 +133,7 @@ def disperse(siblings):
     
     if min_gap == 0:
         for due in best_due_dates.items():
-            if due <= mw.col.sched.today:
-                due = mw.col.sched.today + 1
+            due = max(due, mw.col.sched.today + 1) 
 
     return best_due_dates, due_ranges, min_gap
 

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -130,6 +130,12 @@ def disperse(siblings):
     due_ranges[-1] = (latest_review, latest_review)
     min_gap, best_due_dates = maximize_siblings_due_gap(due_ranges)
     best_due_dates.pop(-1)
+    
+    if min_gap == 0:
+        for due in best_due_dates.items():
+            if due <= mw.col.sched.today:
+                due = due + 1
+
     return best_due_dates, due_ranges, min_gap
 
 
@@ -231,12 +237,12 @@ def disperse_siblings_when_review(reviewer, card: Card, ease):
         card = mw.col.get_card(cid)
         old_due = card.odue if card.odid else card.due
         last_review = get_last_review_date(card)
-        card = update_card_due_ivl(card, due - last_review + 1)
+        card = update_card_due_ivl(card, due - last_review)
         write_custom_data(card, "v", "disperse")
         mw.col.update_card(card)
         mw.col.merge_undo_entries(undo_entry)
         card_cnt += 1
-        message = f"Dispersed card {card.id} from {due_to_date(old_due)} to {due_to_date(due + 1)}"
+        message = f"Dispersed card {card.id} from {due_to_date(old_due)} to {due_to_date(due)}"
         messages.append(message)
 
     if config.debug_notify:

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -134,7 +134,7 @@ def disperse(siblings):
     if min_gap == 0:
         for due in best_due_dates.items():
             if due <= mw.col.sched.today:
-                due = due + 1
+                due = mw.col.sched.today + 1
 
     return best_due_dates, due_ranges, min_gap
 

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -228,11 +228,8 @@ def disperse_siblings_when_review(reviewer, card: Card, ease):
     undo_entry = mw.col.undo_status().last_step
     best_due_dates, due_ranges, min_gap = disperse(siblings)
 
-    if min_gap == 0:
-        for due in best_due_dates.items():
-            due = max(due, mw.col.sched.today + 1)
-    
     for cid, due in best_due_dates.items():
+        due = max(due, mw.col.sched.today + 1)
         card = mw.col.get_card(cid)
         old_due = card.odue if card.odid else card.due
         last_review = get_last_review_date(card)


### PR DESCRIPTION
In https://github.com/open-spaced-repetition/fsrs4anki-helper/issues/259#issuecomment-1783808514, I didn't suggest the following change.

![image](https://github.com/open-spaced-repetition/fsrs4anki-helper/assets/92206575/00e8c898-f9fb-465e-a61c-1e286462037c)

Reason: It affects all the cards, even those that were ideally dispersed before. 

My change only affects the cards where min_gap = 0.

By the way, I am sure that there is some bug in my code (for e.g., are the following lines valid?) Your help in making it functional would be appreciated.

```py
    if min_gap == 0:
        for due in best_due_dates.items():
```
