### PR TITLE
Prevent disperse siblings from modifying "overdue" cards

### DIFF
--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -101,7 +101,7 @@ def get_due_range(cid, stability, due, desired_retention, maximum_interval):
         int((revlogs[0].time - revlogs[1].time) / 86400) if len(revlogs) >= 2 else 0
     )
     min_ivl, max_ivl = get_fuzz_range(new_ivl, last_elapsed_days, maximum_interval)
-    if due > mw.col.sched.today and last_review + max_ivl < mw.col.sched.today:
+    if due > last_review + max_ivl:
         due_range = (due, due)
     elif due >= mw.col.sched.today:
         due_range = (

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -101,7 +101,9 @@ def get_due_range(cid, stability, due, desired_retention, maximum_interval):
         int((revlogs[0].time - revlogs[1].time) / 86400) if len(revlogs) >= 2 else 0
     )
     min_ivl, max_ivl = get_fuzz_range(new_ivl, last_elapsed_days, maximum_interval)
-    if due >= mw.col.sched.today:
+    if due > mw.col.sched.today and last_review + max_ivl < mw.col.sched.today:
+        due_range = (due, due)
+    elif due >= mw.col.sched.today:
         due_range = (
             max(last_review + min_ivl, mw.col.sched.today),
             max(last_review + max_ivl, mw.col.sched.today),


### PR DESCRIPTION
https://www.reddit.com/r/Anki/comments/19e0x2l/comment/kjapnru/

If the users actually want to schedule the cards according to the FSRS algorithm, they should use `Reschedule`. Disperse siblings should not have the same effect as reschedule.