### PR TITLE
Disperse siblings - Create a new fuzz range for cards scheduled beyond max fuzz limit

### DIFF
--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -102,8 +102,9 @@ def get_due_range(cid, stability, due, desired_retention, maximum_interval):
     )
     min_ivl, max_ivl = get_fuzz_range(new_ivl, last_elapsed_days, maximum_interval)
     if due > last_review + max_ivl:
-        due_range = (due, due)
-    elif due >= mw.col.sched.today:
+        # don't reschedule the card to bring it within the fuzz range. Rather, create another fuzz range around the original due date.
+        min_ivl, max_ivl = get_fuzz_range(due - last_review, last_elapsed_days, maximum_interval)
+    if due >= mw.col.sched.today:
         due_range = (
             max(last_review + min_ivl, mw.col.sched.today),
             max(last_review + max_ivl, mw.col.sched.today),

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -101,7 +101,7 @@ def get_due_range(cid, stability, due, desired_retention, maximum_interval):
         int((revlogs[0].time - revlogs[1].time) / 86400) if len(revlogs) >= 2 else 0
     )
     min_ivl, max_ivl = get_fuzz_range(new_ivl, last_elapsed_days, maximum_interval)
-    if due > last_review + max_ivl:
+    if due > last_review + max_ivl + 2: # +2 is just a safeguard to exclude cards that go beyond the fuzz range due to rounding 
         # don't reschedule the card to bring it within the fuzz range. Rather, create another fuzz range around the original due date.
         min_ivl, max_ivl = get_fuzz_range(due - last_review, last_elapsed_days, maximum_interval)
     if due >= mw.col.sched.today:


### PR DESCRIPTION
Follow up of #350

Specifically, to solve:

The current method doesn't allow the card to disperse because the due range is fixed in (due, due).

_Originally posted by @L-M-Sherlock in https://github.com/open-spaced-repetition/fsrs4anki-helper/issues/350#issuecomment-1909275123_