### PR TITLE
Disperse siblings - Prevent further increase in ivl of cards scheduled beyond fuzz range

### DIFF
--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -104,7 +104,7 @@ def get_due_range(cid, stability, due, desired_retention, maximum_interval):
     if due > last_review + max_ivl + 2: # +2 is just a safeguard to exclude cards that go beyond the fuzz range due to rounding 
         # don't reschedule the card to bring it within the fuzz range. Rather, create another fuzz range around the original due date.
         min_ivl, max_ivl = get_fuzz_range(due - last_review, last_elapsed_days, maximum_interval)
-        max_ivl = min(due, max_ivl) # prevent a further increase in ivl
+        max_ivl = min(due - last_review, max_ivl) # prevent a further increase in ivl
         min_ivl = min(min_ivl, max_ivl)
     if due >= mw.col.sched.today:
         due_range = (

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -104,7 +104,7 @@ def get_due_range(cid, stability, due, desired_retention, maximum_interval):
     if due > last_review + max_ivl + 2: # +2 is just a safeguard to exclude cards that go beyond the fuzz range due to rounding 
         # don't reschedule the card to bring it within the fuzz range. Rather, create another fuzz range around the original due date.
         min_ivl, max_ivl = get_fuzz_range(due - last_review, last_elapsed_days, maximum_interval)
-        max_ivl = max(due, max_ivl) # prevent a further increase in ivl
+        max_ivl = min(due, max_ivl) # prevent a further increase in ivl
         min_ivl = min(min_ivl, max_ivl)
     if due >= mw.col.sched.today:
         due_range = (

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -104,6 +104,8 @@ def get_due_range(cid, stability, due, desired_retention, maximum_interval):
     if due > last_review + max_ivl + 2: # +2 is just a safeguard to exclude cards that go beyond the fuzz range due to rounding 
         # don't reschedule the card to bring it within the fuzz range. Rather, create another fuzz range around the original due date.
         min_ivl, max_ivl = get_fuzz_range(due - last_review, last_elapsed_days, maximum_interval)
+        max_ivl = max(due, max_ivl) # prevent a further increase in ivl
+        min_ivl = min(min_ivl, max_ivl)
     if due >= mw.col.sched.today:
         due_range = (
             max(last_review + min_ivl, mw.col.sched.today),


### PR DESCRIPTION
Reasons:
- The card is already scheduled beyond its optimal range. It should not be delayed further.
- If we allow increase in ivl, then on subsequent use of disperse, even larger fuzz ranges would be created, causing unlimited delaying of the card.