### PR TITLE
Disperse siblings - Simplify condition, don't limit non-rescheduled cards to maximum ivl

### DIFF
--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -104,7 +104,8 @@ def get_due_range(cid, stability, due, desired_retention, maximum_interval):
     if due > last_review + max_ivl + 2: # +2 is just a safeguard to exclude cards that go beyond the fuzz range due to rounding 
         # don't reschedule the card to bring it within the fuzz range. Rather, create another fuzz range around the original due date.
         current_ivl = due - last_review
-        min_ivl, max_ivl = get_fuzz_range(current_ivl, last_elapsed_days, current_ivl) # set max_ivl = current_ivl to prevent a further increase in ivl
+        # set maximum_interval = current_ivl to prevent a further increase in ivl
+        min_ivl, max_ivl = get_fuzz_range(current_ivl, last_elapsed_days, current_ivl)
     if due >= mw.col.sched.today:
         due_range = (
             max(last_review + min_ivl, mw.col.sched.today),

--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -103,9 +103,8 @@ def get_due_range(cid, stability, due, desired_retention, maximum_interval):
     min_ivl, max_ivl = get_fuzz_range(new_ivl, last_elapsed_days, maximum_interval)
     if due > last_review + max_ivl + 2: # +2 is just a safeguard to exclude cards that go beyond the fuzz range due to rounding 
         # don't reschedule the card to bring it within the fuzz range. Rather, create another fuzz range around the original due date.
-        min_ivl, max_ivl = get_fuzz_range(due - last_review, last_elapsed_days, maximum_interval)
-        max_ivl = min(due - last_review, max_ivl) # prevent a further increase in ivl
-        min_ivl = min(min_ivl, max_ivl)
+        current_ivl = due - last_review
+        min_ivl, max_ivl = get_fuzz_range(current_ivl, last_elapsed_days, current_ivl) # set max_ivl = current_ivl to prevent a further increase in ivl
     if due >= mw.col.sched.today:
         due_range = (
             max(last_review + min_ivl, mw.col.sched.today),


### PR DESCRIPTION
- Don't use maximum_interval for cards that are currently scheduled beyond their fuzz limit. Bringing the interval within the max limit is not the function of disperse siblings. The user should use Reschedule for this purpose.
Because we don't want disperse siblings to move cards out of the maximum_interval, I have not changed the code for normal cards.
- The code for dealing with maximum_interval was the same as the one I added to ensure that the cards are not delayed further. So, I just replaced maximum_ivl with current_ivl to remove code complexity.