### PR TITLE
Exclude manual entries from remote reviews

### DIFF
--- a/sync_hook.py
+++ b/sync_hook.py
@@ -23,7 +23,7 @@ def review_cid_remote(local_rids: List[int]):
             f"""SELECT DISTINCT cid
             FROM revlog
             WHERE id NOT IN {local_rid_string}
-            {"" if config.auto_disperse_after_reschedule else "AND ease > 0"}
+            AND ease > 0
             AND (type < 3 OR factor != 0)
             """
         )  # type: 0=learn, 1=review, 2=relearn, 3=filtered, 4=manual


### PR DESCRIPTION
Currently, there is no way to distinguish between "Set Due Date" and "Reschedule on change". So, to prevent undoing the "Set Due Date" used on other devices, we need to exclude all manual entries.

When Anki starts using separate revlog entries to distinguish them, we can re-implement the feature of dispersing siblings among cards rescheduled on other devices.