### PR TITLE
Patch for #462

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "auto_disperse_when_review": false,
     "auto_disperse_after_reschedule": false,
     "mature_ivl": 21,
-    "reschedule_threshold": 0.25,
+    "reschedule_threshold": 0,
     "debug_notify": false,
     "fsrs_stats": true,
     "display_memory_state": false,

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -368,7 +368,7 @@ def reschedule_card(cid, fsrs: FSRS, recompute=False):
         fsrs.set_fuzz_factor(cid, card.reps)
         new_ivl = fsrs.fuzzed_next_interval(s)
 
-        if fsrs.reschedule_threshold != 0 and not self.apply_easy_days:
+        if fsrs.reschedule_threshold > 0 and not fsrs.apply_easy_days:
             dr = fsrs.desired_retention
             odds = dr / (1 - dr)
 

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -160,7 +160,7 @@ class FSRS:
             )
             return best_ivl
 
-    def next_interval(self, stability):
+    def fuzzed_next_interval(self, stability):
         new_interval = next_interval(stability, self.desired_retention)
         return self.apply_fuzz(new_interval)
 
@@ -366,21 +366,24 @@ def reschedule_card(cid, fsrs: FSRS, recompute=False):
     if card.type == CARD_TYPE_REV:
         fsrs.set_card(card)
         fsrs.set_fuzz_factor(cid, card.reps)
-        new_ivl = fsrs.next_interval(s)
+        new_ivl = fsrs.fuzzed_next_interval(s)
 
-        dr = fsrs.desired_retention
-        odds = dr / (1 - dr)
-
-        reduced_odds = (1 - fsrs.reschedule_threshold) * odds
-        fsrs.desired_retention = reduced_odds / (reduced_odds + 1)
-        adjusted_ivl_upper = fsrs.next_interval(s)
-
-        increased_odds = (1 + fsrs.reschedule_threshold) * odds
-        fsrs.desired_retention = increased_odds / (increased_odds + 1)
-        adjusted_ivl_lower = fsrs.next_interval(s)
-
-        if card.ivl >= adjusted_ivl_lower and card.ivl <= adjusted_ivl_upper:
-            return None
+        if fsrs.reschedule_threshold != 0 and not self.apply_easy_days:
+            dr = fsrs.desired_retention
+            odds = dr / (1 - dr)
+            
+            odds_lower = (1 - fsrs.reschedule_threshold) * odds
+            fsrs.desired_retention = odds_lower / (odds_lower + 1)
+            adjusted_ivl_upper = next_interval(s)
+            
+            odds_upper = (1 + fsrs.reschedule_threshold) * odds
+            fsrs.desired_retention = odds_upper / (odds_upper + 1)
+            adjusted_ivl_lower = next_interval(s)
+            
+            fsrs.desired_retention = dr
+            
+            if card.ivl >= adjusted_ivl_lower and card.ivl <= adjusted_ivl_upper:
+                return None
 
         due_before = card.odue if card.odid else card.due
         card = update_card_due_ivl(card, new_ivl)

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -371,17 +371,17 @@ def reschedule_card(cid, fsrs: FSRS, recompute=False):
         if fsrs.reschedule_threshold != 0 and not self.apply_easy_days:
             dr = fsrs.desired_retention
             odds = dr / (1 - dr)
-            
+
             odds_lower = (1 - fsrs.reschedule_threshold) * odds
             fsrs.desired_retention = odds_lower / (odds_lower + 1)
             adjusted_ivl_upper = next_interval(s)
-            
+
             odds_upper = (1 + fsrs.reschedule_threshold) * odds
             fsrs.desired_retention = odds_upper / (odds_upper + 1)
             adjusted_ivl_lower = next_interval(s)
-            
+
             fsrs.desired_retention = dr
-            
+
             if card.ivl >= adjusted_ivl_lower and card.ivl <= adjusted_ivl_upper:
                 return None
 


### PR DESCRIPTION
After these changes, https://github.com/open-spaced-repetition/fsrs4anki-helper/pull/462 should be ready for merge. The remaining issues can be tackled in another PR.

Remaining requests/issues:
- When "Disperse siblings after rescheduling" is enabled, reschedule ONLY the sibling whose current interval deviates the most from the ideal one. The disperse function that runs automatically will handle the rest. The reason for this request is to prevent >1 sibling from becoming due after rescheduling. I guess that implementing this would be slightly hard but I think that it's worth it.
- Fixing load balancing requires either creating a new option for Load Balancing or creating a new option for this feature. IMO, the second choice is better because it will also allow the user to completely reschedule their cards even if they don't want to use load balancing.