### PR TITLE
Feat/preset level easy days

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ These two functions are very similar, so I'll talk about them together. You can 
 
 Once the load balance option is enabled, rescheduling will make the daily review load as consistent and smooth as possible.
 
+**Update**: after Anki 24.11, the load balance feature is built-in. So you don't need to enable it in the add-on settings.
+
 ![image](https://github.com/open-spaced-repetition/fsrs4anki-helper/assets/32575846/4ac4f5aa-e4c6-4f50-b30c-1595f930d2f3)
 
 Here's a comparison, the first graph is rescheduling before enabling it, and the second graph is after enabling:
@@ -72,6 +74,8 @@ Here's a comparison, the first graph is rescheduling before enabling it, and the
 ## Easy Days
 
 You can select any day or days from Monday through Sunday to take off. Once enabled, the Helper add-on will try to avoid these days when rescheduling. On "Reduced" days, you will only have ~50% the usual amount of reviews. On "Minimum" days, there will be ~0% reviews.
+
+**Update**: after Anki 24.11, the easy days feature is built-in. So you don't need to configure it in the add-on settings.
 
 Note: Easy Days only works for cards in the "review" stage. Due to technical limitations, FSRS doesn't modify the interval and due date of cards in the "(re)learning" stage. And it also doesn't reschedule cards whose interval is less than 3 days.
 

--- a/__init__.py
+++ b/__init__.py
@@ -239,9 +239,7 @@ menu_for_helper.addAction(menu_auto_disperse)
 menu_for_helper.addAction(menu_display_memory_state)
 menu_for_helper.addAction(menu_show_steps_stats)
 menu_for_helper.addAction(menu_auto_disperse_after_reschedule)
-menu_for_easy_days = menu_for_helper.addMenu(
-    "Less Anki on Easy Days"
-)
+menu_for_easy_days = menu_for_helper.addMenu("Less Anki on Easy Days")
 menu_for_helper.addSeparator()
 menu_for_helper.addAction(menu_reschedule)
 menu_for_helper.addAction(menu_reschedule_recent)

--- a/__init__.py
+++ b/__init__.py
@@ -240,7 +240,7 @@ menu_for_helper.addAction(menu_display_memory_state)
 menu_for_helper.addAction(menu_show_steps_stats)
 menu_for_helper.addAction(menu_auto_disperse_after_reschedule)
 menu_for_easy_days = menu_for_helper.addMenu(
-    "Less Anki on Easy Days (requires Load Balancing)"
+    "Less Anki on Easy Days"
 )
 menu_for_helper.addSeparator()
 menu_for_helper.addAction(menu_reschedule)

--- a/__init__.py
+++ b/__init__.py
@@ -15,7 +15,6 @@ from .schedule.disperse_siblings import disperse_siblings
 from .schedule.easy_days import (
     easy_days,
     easy_day_for_sepcific_date,
-    easy_days_review_ratio,
 )
 from .schedule.remedy import remedy_hard_misuse, undo_remedy
 from .schedule import init_review_hook
@@ -157,15 +156,6 @@ menu_show_steps_stats = checkable(
 )
 
 
-def set_load_balance(checked, _):
-    config.load_balance = checked
-
-
-menu_load_balance = checkable(
-    title="Load Balance when rescheduling", on_click=set_load_balance
-)
-
-
 def reschedule_recent(did):
     reschedule(did, recent=True)
 
@@ -273,7 +263,6 @@ menu_for_helper.addAction(menu_auto_disperse_after_sync)
 menu_for_helper.addAction(menu_auto_disperse)
 menu_for_helper.addAction(menu_display_memory_state)
 menu_for_helper.addAction(menu_show_steps_stats)
-menu_for_helper.addAction(menu_load_balance)
 menu_for_helper.addAction(menu_auto_disperse_after_reschedule)
 menu_for_easy_days = menu_for_helper.addMenu(
     "Less Anki on Easy Days (requires Load Balancing)"
@@ -310,9 +299,6 @@ menu_apply_easy_days_for_specific_date = build_action(
     lambda did: easy_day_for_sepcific_date(did, config),
     "Apply easy days for specific dates",
 )
-menu_easy_days = build_action(
-    lambda did: easy_days_review_ratio(did, config), "Configure easy days"
-)
 
 
 def set_auto_easy_days(checked, _):
@@ -327,8 +313,6 @@ menu_for_auto_easy_days = checkable(
 menu_for_easy_days.addAction(menu_apply_easy_days_for_specific_date)
 menu_for_easy_days.addAction(menu_apply_easy_days)
 menu_for_easy_days.addAction(menu_for_auto_easy_days)
-menu_for_easy_days.addSeparator()
-menu_for_easy_days.addAction(menu_easy_days)
 
 
 def adjust_menu():
@@ -341,7 +325,6 @@ def adjust_menu():
         menu_auto_disperse.setChecked(config.auto_disperse_when_review)
         menu_display_memory_state.setChecked(config.display_memory_state)
         menu_show_steps_stats.setChecked(config.show_steps_stats)
-        menu_load_balance.setChecked(config.load_balance)
         menu_auto_disperse_after_reschedule.setChecked(
             config.auto_disperse_after_reschedule
         )

--- a/config.json
+++ b/config.json
@@ -1,7 +1,5 @@
 {
-    "load_balance": false,
     "easy_dates": [],
-    "easy_days_review_ratio_list": [1, 1, 1, 1, 1, 1, 1],
     "days_to_reschedule": 7,
     "auto_reschedule_after_sync": false,
     "auto_disperse_after_sync": false,

--- a/config.md
+++ b/config.md
@@ -3,13 +3,3 @@
 ### `days_to_reschedule`
 
 This sets the number of days in "Reschedule cards reviewed in the last n days"; the current day included(!). Works like [searching for "rated:" in the browser](https://docs.ankiweb.net/searching.html?highlight=rated#answered).
-
-## Configure via menu bar: Tools > FSRS Helper
-
-### `easy_days`
-
-Load Balancing must be enabled for this. Select any day of the week (e.g., Sunday) when you want to spend less time on Anki. It will reduce reviews on the selected day(s) and instead select another day when rescheduling.
-
-### `load_balance`
-
-Fuzz must be enabled for this (default: enabled, set in the scheduler code). During rescheduling, it keeps the daily number consistent instead of fluctuating.

--- a/configuration.py
+++ b/configuration.py
@@ -2,9 +2,7 @@ from aqt import mw
 
 tag = mw.addonManager.addonFromModule(__name__)
 
-LOAD_BALANCE = "load_balance"
 EASY_DATES = "easy_dates"
-EASY_DAYS_REVIEW_RATIO_LIST = "easy_days_review_ratio_list"
 DAYS_TO_RESCHEDULE = "days_to_reschedule"
 AUTO_RESCHEDULE_AFTER_SYNC = "auto_reschedule_after_sync"
 AUTO_DISPERSE_AFTER_SYNC = "auto_disperse_after_sync"
@@ -42,30 +40,12 @@ class Config:
         save_config(self.data)
 
     @property
-    def load_balance(self):
-        return self.data[LOAD_BALANCE]
-
-    @load_balance.setter
-    def load_balance(self, value):
-        self.data[LOAD_BALANCE] = value
-        self.save()
-
-    @property
     def easy_dates(self) -> list[str]:
         return self.data[EASY_DATES]
 
     @easy_dates.setter
     def easy_dates(self, value):
         self.data[EASY_DATES] = value
-        self.save()
-
-    @property
-    def easy_days_review_ratio_list(self):
-        return self.data[EASY_DAYS_REVIEW_RATIO_LIST]
-
-    @easy_days_review_ratio_list.setter
-    def easy_days_review_ratio_list(self, value):
-        self.data[EASY_DAYS_REVIEW_RATIO_LIST] = value
         self.save()
 
     @property

--- a/schedule/easy_days.py
+++ b/schedule/easy_days.py
@@ -22,27 +22,8 @@ from aqt.gui_hooks import profile_will_close
 def easy_days(did):
     config = Config()
     config.load()
-    if not config.load_balance:
-        tooltip("Please enable load balance first")
-        return
-    if (
-        all([r == 1 for r in config.easy_days_review_ratio_list])
-        and len(config.easy_dates) == 0
-    ):
-        tooltip("Please select easy days or specific dates first")
-        return
     today = mw.col.sched.today
-    due_days = []
-    for day_offset in range(35):
-        if (
-            config.easy_days_review_ratio_list[
-                (sched_current_date() + timedelta(days=day_offset)).weekday()
-            ]
-            < 1
-            or (sched_current_date() + timedelta(days=day_offset)).strftime("%Y-%m-%d")
-            in config.easy_dates
-        ):
-            due_days.append(today + day_offset)
+    due_days = [today + day_offset for day_offset in range(35)]
 
     # find cards that are due in easy days in the next 35 days
     due_in_easy_days_cids = mw.col.db.list(
@@ -62,7 +43,6 @@ def easy_days(did):
         recent=False,
         filter_flag=True,
         filtered_cids=set(due_in_easy_days_cids),
-        apply_easy_days=True,
     )
     if fut:
         return fut.result()
@@ -137,9 +117,6 @@ class EasySpecificDateManagerWidget(QWidget):
         mw.deckBrowser.refresh()
 
     def apply_easy_day_for_specific_date(self):
-        if not self.config.load_balance:
-            tooltip("Please enable load balance first")
-            return
         if len(self.specific_dates) == 0:
             tooltip("Please add the dates first.")
             return
@@ -169,7 +146,6 @@ class EasySpecificDateManagerWidget(QWidget):
             filter_flag=True,
             filtered_cids=set(filtered_dues_cids),
             easy_specific_due_dates=specific_dues,
-            apply_easy_days=True,
         )
 
 
@@ -203,76 +179,3 @@ class DateLabelWidget(QWidget):
 def easy_day_for_sepcific_date(did, config: Config):
     mw.EasySpecificDateManagerWidget = EasySpecificDateManagerWidget(config)
     mw.EasySpecificDateManagerWidget.show()
-
-
-class EasyDaysReviewRatioSelector(QWidget):
-    def __init__(self, config: Config):
-        super().__init__()
-        self.config = config
-        self.layout = QVBoxLayout()
-
-        self.weekdays = [
-            "Monday",
-            "Tuesday",
-            "Wednesday",
-            "Thursday",
-            "Friday",
-            "Saturday",
-            "Sunday",
-        ]
-        self.modes = ["Normal", "Reduced", "Minimum"]
-        self.mode_values = {"Normal": 1.0, "Reduced": 0.5, "Minimum": 0.0}
-
-        self.radio_buttons = {}
-
-        for i, day in enumerate(self.weekdays):
-            day_layout = QHBoxLayout()
-            day_label = QLabel(day)
-            day_layout.addWidget(day_label)
-
-            button_group = QButtonGroup(self)
-            for mode in self.modes:
-                radio_button = QRadioButton(mode)
-                button_group.addButton(radio_button)
-                day_layout.addWidget(radio_button)
-                current_value = self.config.easy_days_review_ratio_list[i]
-                if self.mode_values[mode] == current_value:
-                    radio_button.setChecked(True)
-                self.radio_buttons[f"{day}_{mode}"] = radio_button
-
-            self.layout.addLayout(day_layout)
-
-        self.saveBtn = QPushButton("Save")
-        self.saveBtn.clicked.connect(self.save_settings)
-        self.layout.addWidget(self.saveBtn)
-
-        self.setLayout(self.layout)
-        self.setWindowTitle("Set the review amount for each day of the week")
-        self.resize(400, 250)
-
-    def save_settings(self):
-        # Check if there is at least one Normal day
-        normal_days = sum(
-            self.radio_buttons[f"{day}_Normal"].isChecked() for day in self.weekdays
-        )
-
-        if normal_days == 0:
-            tooltip("At least one day must be set to Normal")
-            return
-
-        settings = []
-        for day in self.weekdays:
-            for mode in self.modes:
-                if self.radio_buttons[f"{day}_{mode}"].isChecked():
-                    settings.append(self.mode_values[mode])
-                    break
-            else:
-                settings.append(1.0)  # Default value if no mode is selected
-
-        self.config.easy_days_review_ratio_list = settings
-        self.close()
-
-
-def easy_days_review_ratio(did, config: Config):
-    mw.easyDaysReviewRatioSelector = EasyDaysReviewRatioSelector(config)
-    mw.easyDaysReviewRatioSelector.show()

--- a/schedule/easy_days.py
+++ b/schedule/easy_days.py
@@ -43,6 +43,7 @@ def easy_days(did):
         recent=False,
         filter_flag=True,
         filtered_cids=set(due_in_easy_days_cids),
+        apply_easy_days=True,
     )
     if fut:
         return fut.result()
@@ -146,6 +147,7 @@ class EasySpecificDateManagerWidget(QWidget):
             filter_flag=True,
             filtered_cids=set(filtered_dues_cids),
             easy_specific_due_dates=specific_dues,
+            apply_easy_days=True,
         )
 
 

--- a/schedule/flatten.py
+++ b/schedule/flatten.py
@@ -49,10 +49,6 @@ def flatten_background(did, desired_flatten_limit):
     config = Config()
     config.load()
 
-    easy_days_review_ratio_list = []
-    if config.load_balance:
-        easy_days_review_ratio_list = config.easy_days_review_ratio_list
-
     DM = DeckManager(mw.col)
     if did is not None:
         did_list = ids2str(DM.deck_and_child_ids(did))
@@ -148,14 +144,9 @@ def flatten_background(did, desired_flatten_limit):
         rest_cnt = len(cards_to_flatten) - cnt
         if rest_cnt <= 0:
             break
-        due_date = current_date + timedelta(days=new_due - today)
+        # due_date = current_date + timedelta(days=new_due - today)
         due_cnt = due_cnt_per_day[new_due]
-        today_limit = (
-            int(desired_flatten_limit * easy_days_review_ratio_list[due_date.weekday()])
-            if config.load_balance
-            else desired_flatten_limit
-        )
-        quota = today_limit - due_cnt
+        quota = desired_flatten_limit - due_cnt
         if quota <= 0:
             continue
         start_index = cnt

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -32,6 +32,7 @@ class FSRS:
     today: int
     did: int
     did_to_preset_id: Dict[int, int]
+    preset_id_to_easy_days_percentages: Dict[int, List[float]]
 
     def __init__(self) -> None:
         self.reschedule_threshold = 0
@@ -58,11 +59,13 @@ class FSRS:
 
         self.due_cnt_per_day_per_preset = defaultdict(lambda: defaultdict(int))
         self.did_to_preset_id = {}
+        self.preset_id_to_easy_days_percentages = {}
 
         for did, due_date, count in deck_stats:
             preset_id = self.DM.config_dict_for_deck_id(did)["id"]
             self.due_cnt_per_day_per_preset[preset_id][due_date] += count
             self.did_to_preset_id[did] = preset_id
+            self.preset_id_to_easy_days_percentages[preset_id] = self.DM.config_dict_for_deck_id(did)["easyDaysPercentages"]
 
         self.due_today_per_preset = defaultdict(
             int,
@@ -121,9 +124,7 @@ class FSRS:
 
     @property
     def easy_days_review_ratio_list(self):
-        easy_days_percentages = self.DM.config_dict_for_deck_id(self.did)[
-            "easyDaysPercentages"
-        ]
+        easy_days_percentages = self.preset_id_to_easy_days_percentages[self.preset_id]
         return easy_days_percentages if easy_days_percentages else [1] * 7
 
     def set_fuzz_factor(self, cid: int, reps: int):

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -65,7 +65,9 @@ class FSRS:
             preset_id = self.DM.config_dict_for_deck_id(did)["id"]
             self.due_cnt_per_day_per_preset[preset_id][due_date] += count
             self.did_to_preset_id[did] = preset_id
-            self.preset_id_to_easy_days_percentages[preset_id] = self.DM.config_dict_for_deck_id(did)["easyDaysPercentages"]
+            self.preset_id_to_easy_days_percentages[preset_id] = (
+                self.DM.config_dict_for_deck_id(did)["easyDaysPercentages"]
+            )
 
         self.due_today_per_preset = defaultdict(
             int,


### PR DESCRIPTION
Because the smart fuzz has been built-in, so the load balance option has been removed. The load balance and easy days are always applied when rescheduling via the helper add-on.

Patch: [fsrs4anki-helper.ankiaddon.zip](https://github.com/user-attachments/files/17967907/fsrs4anki-helper.ankiaddon.zip)

After this PR, I will release a new branch in Ankiweb.

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/a1d0e37e-3e32-40da-9538-bee4144ce06a">

The new branch will only support Anki 24.11+ versions.