### PR TITLE
Feat/Disperse siblings among cards rescheduled on another device

### DIFF
--- a/sync_hook.py
+++ b/sync_hook.py
@@ -23,10 +23,10 @@ def review_cid_remote(local_rids: List[int]):
             f"""SELECT DISTINCT cid
             FROM revlog
             WHERE id NOT IN {local_rid_string}
-            AND ease > 0
+            {"AND type != 4" if config.auto_disperse_after_reschedule else "AND ease > 0"}
             AND (type < 3 OR factor != 0)
             """
-        )  # type: 0=learn, 1=review, 2=relearn, 3=filtered, 4=manual
+        )  # type: 0=learn, 1=review, 2=relearn, 3=filtered, 4=manual, 5=reschedule
     ]
     return remote_reviewed_cids
 


### PR DESCRIPTION
Essentially, a revert of https://github.com/open-spaced-repetition/fsrs4anki-helper/pull/434. We can now distinguish between "Set Due Date" and "Reschedule on change".

This is useful even if Desktop Anki < 24.11 because the other device may have Anki 24.11+.