### PR TITLE
Feat/skip manually scheduled cards when rescheduling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -110,31 +110,6 @@ menu_auto_disperse_after_reschedule = checkable(
 )
 
 
-def set_skip_manual_resched_cards(checked, _):
-    if config.skip_manual_resched_cards:
-        config.skip_manual_resched_cards = checked
-    else:
-        warning = (
-            "Due to the nature of Anki's database, FSRS Helper cannot distinguish among cards rescheduled by following operations:\n"
-            + "- Set due date\n"
-            + "- Reset (earlier called Forget)\n"
-            + "- 'Reschedule cards on change' in FSRS section of Deck Options\n\n"
-            + "When you enable this option, cards that were last modified by any of the above will be skipped during rescheduling."
-        )
-        checked = askUser(
-            warning,
-            title="Warning",
-        )
-        config.skip_manual_resched_cards = checked
-        menu_skip_manual_resched_cards.setChecked(checked)
-
-
-menu_skip_manual_resched_cards = checkable(
-    title="Skip manually rescheduled cards when rescheduling",
-    on_click=set_skip_manual_resched_cards,
-)
-
-
 def set_display_memory_state(checked, _):
     config.display_memory_state = checked
 
@@ -278,7 +253,6 @@ menu_for_helper.addAction(menu_auto_disperse_after_reschedule)
 menu_for_easy_days = menu_for_helper.addMenu(
     "Less Anki on Easy Days (requires Load Balancing)"
 )
-menu_for_helper.addAction(menu_skip_manual_resched_cards)
 menu_for_helper.addSeparator()
 menu_for_helper.addAction(menu_reschedule)
 menu_for_helper.addAction(menu_reschedule_recent)
@@ -345,7 +319,6 @@ def adjust_menu():
         menu_auto_disperse_after_reschedule.setChecked(
             config.auto_disperse_after_reschedule
         )
-        menu_skip_manual_resched_cards.setChecked(config.skip_manual_resched_cards)
         menu_for_auto_easy_days.setChecked(config.auto_easy_days)
 
 

--- a/config.json
+++ b/config.json
@@ -15,6 +15,5 @@
     "auto_easy_days": false,
     "has_rated": false,
     "has_sponsored": false,
-    "skip_manual_resched_cards": false,
     "show_steps_stats": false
 }

--- a/configuration.py
+++ b/configuration.py
@@ -18,7 +18,6 @@ DISPLAY_MEMORY_STATE = "display_memory_state"
 AUTO_EASY_DAYS = "auto_easy_days"
 HAS_RATED = "has_rated"
 HAS_SPONSORED = "has_sponsored"
-SKIP_MANUAL_RESCHED_CARDS = "skip_manual_resched_cards"
 SHOW_STEPS_STATS = "show_steps_stats"
 
 
@@ -183,15 +182,6 @@ class Config:
     @has_sponsored.setter
     def has_sponsored(self, value):
         self.data[HAS_SPONSORED] = value
-        self.save()
-
-    @property
-    def skip_manual_resched_cards(self):
-        return self.data[SKIP_MANUAL_RESCHED_CARDS]
-
-    @skip_manual_resched_cards.setter
-    def skip_manual_resched_cards(self, value):
-        self.data[SKIP_MANUAL_RESCHED_CARDS] = value
         self.save()
 
     @property

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -307,16 +307,6 @@ def reschedule_background(
     if filter_flag:
         filter_query = f"AND id IN {ids2str(filtered_cids)}"
 
-    if config.skip_manual_resched_cards:
-        skip_query = """
-                AND id NOT IN (
-                    SELECT cid
-                    FROM revlog
-                    GROUP BY cid
-                    HAVING MAX(CASE WHEN ease = 0 THEN id ELSE NULL END) = MAX(id)
-                )
-            """
-
     cid_did_nid = mw.col.db.all(
         f"""
         SELECT 
@@ -331,7 +321,12 @@ def reschedule_background(
         {did_query if did_query is not None else ""}
         {recent_query if recent else ""}
         {filter_query if filter_flag else ""}
-        {skip_query if config.skip_manual_resched_cards else ""}
+        AND id NOT IN (
+                    SELECT cid
+                    FROM revlog
+                    GROUP BY cid
+                    HAVING MAX(CASE WHEN type = 4 THEN id ELSE NULL END) = MAX(id)
+                )
         ORDER BY ivl
     """
     )


### PR DESCRIPTION
Because we can now distinguish between "Set Due Date" and "Reschedule on change", we don't need to add a separate configurable option.

This PR should be merged into main only after a separate branch is created for 23.10-24.06.3