### PR TITLE
Fix/Replace en locale with en_US

### DIFF
--- a/i18n.py
+++ b/i18n.py
@@ -6,6 +6,9 @@ from aqt import mw
 from aqt.utils import tr
 
 locale = mw.pm.meta["defaultLang"]
+if locale == "en":
+    locale = "en_US"
+
 addon_dir = Path(os.path.dirname(__file__))
 
 i18n.load_path.append(addon_dir / "locale")


### PR DESCRIPTION
fixes #543

This is a complete guess but the only way I can reproduce this error to occur is if `mw.pm.meta["defaultLang"] == "en"`.
I'm guessing that this may have been the case in a previous version of Anki but am not sure.

It appears this is caused by the use of `in` here.
https://github.com/danhper/python-i18n/blob/4b7deea70b07b4286c96a59cc176abe14784b360/i18n/resource_loader.py#L91

Relevant issue: https://github.com/danhper/python-i18n/issues/43