### PR TITLE
Feat/Dataset Export for Research

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,8 @@
+from pathlib import Path
 from aqt.gui_hooks import deck_browser_will_show_options_menu, state_did_change
 from aqt import mw
 from aqt.qt import QAction
-from aqt.utils import tooltip, openLink, askUser
+from aqt.utils import tooltip, openLink, askUser, showInfo
 from typing import Callable
 
 from .dsr_state import init_dsr_status_hook
@@ -211,6 +212,17 @@ def sponsor(did=None):
 menu_sponsor = build_action(sponsor, t("sponsor-author"))
 
 
+def export_dataset(did=None):
+    addon = mw.addonManager.addonFromModule(__name__)
+    user_files = Path(mw.addonManager.addonsFolder(addon)) / "user_files"
+    user_files.mkdir(parents=True, exist_ok=True)
+    mw.col.export_dataset_for_research(f"{user_files}/{mw.pm.name}.revlog")
+    showInfo(f"Your dataset has been exported to {user_files}/{mw.pm.name}.revlog")
+
+
+menu_export_dataset = build_action(export_dataset, t("export-dataset"))
+
+
 def pass_fail(did=None):
     openLink("https://ankiweb.net/shared/info/876946123")
 
@@ -261,6 +273,7 @@ if not config.has_rated:
     menu_for_helper.addAction(menu_rate)
 if not config.has_sponsored:
     menu_for_helper.addAction(menu_sponsor)
+menu_for_helper.addAction(menu_export_dataset)
 menu_for_helper.addSeparator()
 menu_for_recommended_addons = menu_for_helper.addMenu(t("recommended-addons"))
 menu_for_recommended_addons.addAction(menu_pass_fail)

--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from aqt.gui_hooks import deck_browser_will_show_options_menu, state_did_change
 from aqt import mw
-from aqt.qt import QAction
-from aqt.utils import tooltip, openLink, askUser, showInfo
+from aqt.qt import QAction, QDesktopServices, QUrl
+from aqt.utils import openLink, askUser
 from typing import Callable
 
 from .dsr_state import init_dsr_status_hook
@@ -217,7 +217,7 @@ def export_dataset(did=None):
     user_files = Path(mw.addonManager.addonsFolder(addon)) / "user_files"
     user_files.mkdir(parents=True, exist_ok=True)
     mw.col.export_dataset_for_research(f"{user_files}/{mw.pm.name}.revlog")
-    showInfo(f"Your dataset has been exported to {user_files}/{mw.pm.name}.revlog")
+    QDesktopServices.openUrl(QUrl.fromLocalFile(str(user_files.absolute())))
 
 
 menu_export_dataset = build_action(export_dataset, t("export-dataset"))

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -32,6 +32,7 @@
     "rate-addon": "Rate Add-on on AnkiWeb",
     "visualize-schedule": "Visualize Your FSRS Schedule",
     "sponsor-author": "Sponsor the Author",
+    "export-dataset": "Export Dataset for Research",
     "pass-fail": "Pass/Fail",
     "ajt-card-management": "AJT Card Management",
     "search-stats-extended": "Search Stats Extended",


### PR DESCRIPTION
It is helpful if we want to analyze certain user's collection. The exported `*.revlog` file could be converted to `parquet` files like this: https://github.com/open-spaced-repetition/anki-revlogs-dataset-builder/blob/main/build_parquet.py

## Changes
- Added a new menu item "Export Dataset for Research" under the helper menu
- Implemented `export_dataset()` function to export user's review logs
- Added corresponding translation string in English locale
- Created a dedicated `user_files` directory to store exported datasets

## Implementation Details
- The exported dataset is saved in the addon's `user_files` directory
- The filename is based on the user's profile name with `.revlog` extension
- The feature is accessible through the helper menu alongside other options