### PR TITLE
Ignore reschedule_threshold if called by auto_reschedule

### DIFF
--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -375,11 +375,11 @@ def reschedule_background(
         fsrs.desired_retention = desired_retention
         fsrs.maximum_interval = maximum_interval
         fsrs.did = did
-        card, interval_updated = reschedule_card(cid, fsrs, filter_flag)
+        card, interval_updated = reschedule_card(cid, fsrs, filter_flag, auto_reschedule)
         if card is None:
             continue
         rescheduled_cards.append(card)
-        if interval_updated or auto_reschedule:
+        if interval_updated:
             filtered_nids.add(nid)
             cnt += 1
         if cnt % 500 == 0:
@@ -404,7 +404,7 @@ def reschedule_background(
     return finish_text
 
 
-def reschedule_card(cid, fsrs: FSRS, recompute=False):
+def reschedule_card(cid, fsrs: FSRS, recompute=False, auto_reschedule=False):
     card = mw.col.get_card(cid)
     if recompute:
         memory_state = mw.col.compute_memory_state(cid)
@@ -426,7 +426,7 @@ def reschedule_card(cid, fsrs: FSRS, recompute=False):
         decay = get_decay(card)
         new_ivl = fsrs.fuzzed_next_interval(s, -decay)
 
-        if fsrs.reschedule_threshold > 0 and not fsrs.apply_easy_days:
+        if fsrs.reschedule_threshold > 0 and not (fsrs.apply_easy_days or auto_reschedule):
             dr = fsrs.desired_retention
             odds = dr / (1 - dr)
 

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -426,7 +426,9 @@ def reschedule_card(cid, fsrs: FSRS, recompute=False, auto_reschedule=False):
         decay = get_decay(card)
         new_ivl = fsrs.fuzzed_next_interval(s, -decay)
 
-        if fsrs.reschedule_threshold > 0 and not (fsrs.apply_easy_days or auto_reschedule):
+        if fsrs.reschedule_threshold > 0 and not (
+            fsrs.apply_easy_days or auto_reschedule
+        ):
             dr = fsrs.desired_retention
             odds = dr / (1 - dr)
 

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -231,6 +231,7 @@ def reschedule(
     filtered_cids={},
     easy_specific_due_dates=[],
     apply_easy_days=False,
+    auto_reschedule=False,
 ):
     if not mw.col.get_config("fsrs"):
         tooltip(t("enable-fsrs-warning"))
@@ -266,6 +267,7 @@ def reschedule(
             filtered_cids,
             easy_specific_due_dates,
             apply_easy_days,
+            auto_reschedule,
         ),
         on_done,
     )
@@ -280,6 +282,7 @@ def reschedule_background(
     filtered_cids={},
     easy_specific_due_dates=[],
     apply_easy_days=False,
+    auto_reschedule=False,
 ):
     config = Config()
     config.load()
@@ -376,7 +379,7 @@ def reschedule_background(
         if card is None:
             continue
         rescheduled_cards.append(card)
-        if interval_updated:
+        if interval_updated or auto_reschedule:
             filtered_nids.add(nid)
             cnt += 1
         if cnt % 500 == 0:

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -375,7 +375,9 @@ def reschedule_background(
         fsrs.desired_retention = desired_retention
         fsrs.maximum_interval = maximum_interval
         fsrs.did = did
-        card, interval_updated = reschedule_card(cid, fsrs, filter_flag, auto_reschedule)
+        card, interval_updated = reschedule_card(
+            cid, fsrs, filter_flag, auto_reschedule
+        )
         if card is None:
             continue
         rescheduled_cards.append(card)

--- a/sync_hook.py
+++ b/sync_hook.py
@@ -48,6 +48,7 @@ def auto_reschedule(local_rids: List[int], texts: List[str]):
         recent=False,
         filter_flag=True,
         filtered_cids=set(remote_reviewed_cids),
+        auto_reschedule=True,
     )
 
     if fut:


### PR DESCRIPTION
If the card is being rescheduled by auto_reschedule after sync, there is no reason to not reschedule it even if the interval didn't change much. The purpose of reschedule_threshold is to avoid backlogs. Backlog won't be created by rescheduling cards that were studied today on a different device.