### PR TITLE
Fix/ Exclude some cards from failed to postpone message

### DIFF
--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -124,7 +124,7 @@
     "postpone": "Postpone",
     "postpone-result-text": "%{count} cards postponed in %{seconds} seconds.",
     "postpone-retention-change": "<br>Mean target retention of postponed cards: %{prev_retention} -> %{new_retention}",
-    "postpone-reach-max-ivl": "<br>Failed to postpone %{reach_max_ivl_cnt} cards due to maximum interval.",
+    "postpone-reach-max-ivl": "<br>Failed to postpone %{reach_max_ivl_cnt} cards because they had already reached the configured maximum interval.",
 
     "remedy-start-date": "Select the Start Date",
     "remedy-end-date": "Select the End Date",

--- a/locale/zh_CN.json
+++ b/locale/zh_CN.json
@@ -123,7 +123,7 @@
     "postpone": "推迟",
     "postpone-result-text": "在 %{seconds} 秒内推迟了 %{count} 张卡片。",
     "postpone-retention-change": "<br>推迟卡片的平均目标保留率：%{prev_retention} -> %{new_retention}",
-    "postpone-reach-max-ivl": "<br>由于最大间隔，无法推迟 %{reach_max_ivl_cnt} 张卡片。",
+    "postpone-reach-max-ivl": "<br>未能推迟 %{reach_max_ivl_cnt} 张卡片，因为它们已达到配置的最大间隔。",
 
     "remedy-start-date": "选择开始日期",
     "remedy-end-date": "选择结束日期",

--- a/schedule/postpone.py
+++ b/schedule/postpone.py
@@ -119,7 +119,7 @@ def postpone(did):
         random.seed(cid + ivl)
         last_review = get_last_review_date(card)
         elapsed_days = mw.col.sched.today - last_review
-        delay = elapsed_days - ivl
+        delay = max(elapsed_days - ivl, 0)
         new_ivl = min(
             max(1, math.ceil(ivl * (1.05 + 0.05 * random.random())) + delay), max_ivl
         )

--- a/schedule/postpone.py
+++ b/schedule/postpone.py
@@ -123,7 +123,7 @@ def postpone(did):
         new_ivl = min(
             max(1, math.ceil(ivl * (1.05 + 0.05 * random.random())) + delay), max_ivl
         )
-        if new_ivl <= ivl:
+        if new_ivl <= ivl and new_ivl = max_ivl:
             reach_max_ivl_cnt += 1
         card = update_card_due_ivl(card, new_ivl)
         write_custom_data(card, "v", "postpone")

--- a/schedule/postpone.py
+++ b/schedule/postpone.py
@@ -120,10 +120,11 @@ def postpone(did):
         last_review = get_last_review_date(card)
         elapsed_days = mw.col.sched.today - last_review
         delay = elapsed_days - ivl
-        new_ivl = max(1, math.ceil(ivl * (1.05 + 0.05 * random.random())) + delay)
-        if new_ivl > max_ivl:
+        new_ivl = min(
+            max(1, math.ceil(ivl * (1.05 + 0.05 * random.random())) + delay), max_ivl
+        )
+        if new_ivl <= ivl:
             reach_max_ivl_cnt += 1
-            new_ivl = max_ivl
         card = update_card_due_ivl(card, new_ivl)
         write_custom_data(card, "v", "postpone")
         postponed_cards.append(card)

--- a/schedule/postpone.py
+++ b/schedule/postpone.py
@@ -123,7 +123,7 @@ def postpone(did):
         new_ivl = min(
             max(1, math.ceil(ivl * (1.05 + 0.05 * random.random())) + delay), max_ivl
         )
-        if new_ivl <= ivl and new_ivl = max_ivl:
+        if new_ivl <= ivl and new_ivl == max_ivl:
             reach_max_ivl_cnt += 1
         card = update_card_due_ivl(card, new_ivl)
         write_custom_data(card, "v", "postpone")


### PR DESCRIPTION
If the previous ivl is less than max_ivl, the card will be postponed, though not by the same amount it would have been postponed if the max_ivl limit wasn't set. So, these cards shouldn't be counted in the "failed to postpone" message.