### PR TITLE
Match Anki's load balancer and slightly improve performance

### DIFF
--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -155,7 +155,7 @@ class FSRS:
         last_review: int,
     ):
         weights = [
-            1 if r == 0 else (1 / (r**2)) * (1 / delta_t)
+            1 if r == 0 else (1 / (r**2.15)) * (1 / (delta_t**3))
             for r, delta_t in zip(review_cnts, possible_intervals)
         ]
 

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -428,7 +428,6 @@ def reschedule_card(cid, fsrs: FSRS, recompute=False, auto_reschedule=False):
         fsrs.set_card(card)
         fsrs.set_fuzz_factor(cid, card.reps)
         decay = get_decay(card)
-        new_ivl = fsrs.fuzzed_next_interval(s, -decay)
 
         if fsrs.reschedule_threshold > 0 and not (
             fsrs.apply_easy_days or auto_reschedule
@@ -450,6 +449,7 @@ def reschedule_card(cid, fsrs: FSRS, recompute=False, auto_reschedule=False):
                 else:
                     return None, False
 
+        new_ivl = fsrs.fuzzed_next_interval(s, -decay)
         due_before = card.odue if card.odid else card.due
         card = update_card_due_ivl(card, new_ivl)
         write_custom_data(card, "v", "reschedule")


### PR DESCRIPTION
Before the second commit:
```
1629 cards rescheduled, 896 cards in 448 notes dispersed in 0.87 seconds
```

After the second commit:
```
1629 cards rescheduled, 896 cards in 448 notes dispersed in 0.85 seconds
```
