### PR TITLE
Show step stats for all decks sharing a preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Interpretation:
 
 ![](https://github.com/user-attachments/assets/3d1a9865-654d-4074-8eb5-2f905a4fdf69)
 
-The Steps Stats are based on the cards from the selected deck or collection that were first reviewed in the last 1 month/year or deck life and have at least two reviews.
+The Steps Stats are based on cards that were first reviewed in the last 1 month/year or deck life and have at least two reviews. When a deck is selected, FSRS Helper aggregates over all decks that use the same preset. When the whole collection is selected, it keeps the whole-collection scope.
 
 These stats are helpful for fine-tuning your (re)learning steps to achieve your desired retention in the short-term reviews. 
 

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -59,6 +59,8 @@
     "step-stats": "Step Stats",
     "step-stats-disabled": "If you would like to see your (re)learning step statistics, you can enable them with <code>Tools > FSRS Helper > Show step stats.</code><br/><br/>This graph will slow down the speed at which this page loads if you have a lot of reviews, so enable it with caution.",
     "step-stats-subtitle": "Statistics for different first ratings during (re)learning steps",
+    "step-stats-scope-collection": "Scope: whole collection.",
+    "step-stats-scope-preset": "Scope: all decks using preset %{preset_name}.",
     "again-then-good": "Again Then Good",
     "good-then-again": "Good Then Again",
     "first-ratings": "First ratings",

--- a/stats.py
+++ b/stats.py
@@ -1,5 +1,8 @@
+import html
+
 from aqt.utils import tooltip
 from anki.stats import CollectionStats
+from anki.utils import ids2str
 from .configuration import Config
 from .steps import steps_stats
 from .i18n import t
@@ -88,6 +91,35 @@ def todayStats_new(self):
     )
 
 
+def get_step_stats_scope(self: CollectionStats) -> tuple[str, str]:
+    card_lim = self._revlogLimit()
+    if self.wholeCollection or not card_lim:
+        return card_lim, t("step-stats-scope-collection")
+
+    current_deck = self.col.decks.current()
+    if not current_deck or current_deck.get("dyn"):
+        return card_lim, ""
+
+    preset_id = current_deck.get("conf") if current_deck else None
+    if preset_id is None:
+        return card_lim, ""
+
+    preset = self.col.decks.get_config(preset_id) or {}
+    preset_name = preset.get("name") or str(preset_id)
+    scoped_deck_ids = [
+        deck["id"]
+        for deck in self.col.decks.all()
+        if deck.get("conf") == preset_id and not deck.get("dyn")
+    ]
+    if not scoped_deck_ids:
+        return card_lim, ""
+
+    return (
+        "cid in (select id from cards where did in %s)" % ids2str(scoped_deck_ids),
+        t("step-stats-scope-preset", preset_name=html.escape(preset_name)),
+    )
+
+
 def get_steps_stats(self: CollectionStats):
     config = Config()
     config.load()
@@ -100,14 +132,16 @@ def get_steps_stats(self: CollectionStats):
         )
     else:
         period_lim = ""
-    deck_lim = self._revlogLimit()
-    results = steps_stats(deck_lim, period_lim)
+    card_lim, scope_note = get_step_stats_scope(self)
+    results = steps_stats(card_lim, period_lim)
 
     title = CollectionStats._title(
         self,
         t("step-stats"),
         t("step-stats-subtitle"),
     )
+
+    scope_note_html = f"<p><em>{scope_note}</em></p>" if scope_note else ""
 
     html = (
         """
@@ -336,7 +370,7 @@ def get_steps_stats(self: CollectionStats):
         + t("step-stats-help-line-7")
         + "</li></ul> </td></tr></table>"
     )
-    return self._section(title + html)
+    return self._section(title + scope_note_html + html)
 
 
 def get_fsrs_stats(self: CollectionStats):

--- a/steps.py
+++ b/steps.py
@@ -31,14 +31,14 @@ def fit_forgetting_curve(points, low=1, high=86400 * 30, tolerance=0.1):
     return (high + low) / 2
 
 
-def steps_stats(deck_lim, period_lim):
+def steps_stats(card_lim, period_lim):
     sql = f"""
     WITH first_review AS (
     SELECT cid, MIN(id) AS first_id, ease AS first_rating
     FROM revlog
     WHERE ease BETWEEN 1 AND 4
     AND type = {REVLOG_LRN}
-    {"AND " + deck_lim if deck_lim else ""}
+    {"AND " + card_lim if card_lim else ""}
     GROUP BY cid
     {"HAVING " + period_lim if period_lim else ""}
     ),
@@ -69,7 +69,7 @@ def steps_stats(deck_lim, period_lim):
         FROM revlog
         WHERE ease BETWEEN 1 AND 4
         AND type = {REVLOG_LRN}
-        {"AND " + deck_lim if deck_lim else ""}
+        {"AND " + card_lim if card_lim else ""}
         GROUP BY cid
         HAVING first_rating = 1
         {"AND " + period_lim if period_lim else ""}
@@ -110,7 +110,7 @@ def steps_stats(deck_lim, period_lim):
         FROM revlog
         WHERE ease BETWEEN 1 AND 4
         AND type = {REVLOG_LRN}
-        {"AND " + deck_lim if deck_lim else ""}
+        {"AND " + card_lim if card_lim else ""}
         GROUP BY cid
         HAVING first_rating = 3
         {"AND " + period_lim if period_lim else ""}
@@ -150,7 +150,7 @@ def steps_stats(deck_lim, period_lim):
         SELECT cid, id AS first_id
         FROM revlog
         WHERE type = {REVLOG_REV} AND ease = 1
-        {"AND " + deck_lim if deck_lim else ""}
+        {"AND " + card_lim if card_lim else ""}
         {"AND " + period_lim if period_lim else ""}
     ),
     next_review AS (


### PR DESCRIPTION
Fixes #523.

## Summary

When opening Steps Stats on the old stats page for a deck, FSRS Helper now aggregates over all non-filtered decks that use the same preset instead of limiting the stats to the selected deck or deck subtree.

## Why

Users who split one preset across multiple decks could only inspect step stats for a single deck or for the whole collection. That made it hard to tune (re)learning steps at the preset level.

## Changes

- derive a preset-scoped card filter from the selected deck
- reuse that filter for all Steps Stats queries
- keep whole-collection behavior unchanged
- exclude filtered decks from preset aggregation
- show the current stats scope in the UI
- update the README wording to match the new behavior

## Screenshots

### Before
<img width="1600" height="1656" alt="before2" src="https://github.com/user-attachments/assets/6b6ea7ee-e7a0-4753-ac9a-869f8f0930db" />



### After

<img width="1600" height="1656" alt="after2" src="https://github.com/user-attachments/assets/5ad59a4c-1840-41c1-a2a7-481fed90600c" />

