### PR TITLE
Feat: Push rescheduled cards after auto-reschedule/disperse

### DIFF
--- a/schedule/disperse_siblings.py
+++ b/schedule/disperse_siblings.py
@@ -1,10 +1,12 @@
 import time
 from typing import Dict, Tuple
+
+from anki.cards import Card
 from anki.utils import ids2str
 from aqt.utils import tooltip
-from anki.cards import Card
-from ..i18n import t
+
 from ..configuration import Config
+from ..i18n import t
 from ..utils import *
 
 
@@ -17,7 +19,7 @@ def get_siblings(did=None, filter_flag=False, filtered_nid_string=""):
         nid_query = f"AND nid IN {filtered_nid_string}"
 
     siblings = mw.col.db.all(f"""
-    SELECT 
+    SELECT
         id,
         nid,
         CASE WHEN odid==0
@@ -72,7 +74,7 @@ def get_siblings(did=None, filter_flag=False, filtered_nid_string=""):
 
 def get_siblings_when_review(card: Card):
     siblings = mw.col.db.all(f"""
-    SELECT 
+    SELECT
         id,
         CASE WHEN odid==0
         THEN did
@@ -170,10 +172,11 @@ def disperse_siblings(
 
     def on_done(future):
         mw.progress.finish()
+        _, result = future.result()
         tooltip(
             t(
                 "disperse-result",
-                result=future.result(),
+                result=result,
                 count=f"{time.time() - start_time:.2f}",
             )
         )
@@ -231,7 +234,8 @@ def disperse_siblings_background(
 
     mw.col.update_cards(dispersed_cards)
     mw.col.merge_undo_entries(undo_entry)
-    return f"{text_from_reschedule + ', ' if text_from_reschedule != '' else ''}{card_cnt} {t('disperse-cards-in')} {note_cnt} {t('disperse-notes')}"
+    result_text = f"{text_from_reschedule + ', ' if text_from_reschedule != '' else ''}{card_cnt} {t('disperse-cards-in')} {note_cnt} {t('disperse-notes')}"
+    return card_cnt, result_text
 
 
 def disperse_siblings_when_review(reviewer, card: Card, ease):

--- a/schedule/reschedule.py
+++ b/schedule/reschedule.py
@@ -265,12 +265,12 @@ def reschedule(
         config = Config()
         config.load()
         if config.auto_disperse_after_reschedule:
-            finish_text, filtered_nid_string = future.result()
+            _, finish_text, filtered_nid_string = future.result()
             mw.progress.finish()
             mw.reset()
             disperse_siblings(did, True, filtered_nid_string, finish_text)
         else:
-            finish_text = future.result()
+            _, finish_text = future.result()
             mw.progress.finish()
             tooltip(
                 t(
@@ -436,9 +436,9 @@ def reschedule_background(
 
     if config.auto_disperse_after_reschedule:
         filtered_nid_string = ids2str(filtered_nids)
-        return (finish_text, filtered_nid_string)
+        return (cnt, finish_text, filtered_nid_string)
 
-    return finish_text
+    return (cnt, finish_text)
 
 
 def reschedule_card(cid, fsrs: FSRS, recompute=False, auto_reschedule=False):

--- a/sync_hook.py
+++ b/sync_hook.py
@@ -1,11 +1,14 @@
-from aqt.gui_hooks import sync_will_start, sync_did_finish
-from anki.utils import ids2str
 from typing import List
-from .schedule.reschedule import reschedule
-from .schedule.disperse_siblings import disperse_siblings
+
+from anki.utils import ids2str
+from aqt.gui_hooks import sync_did_finish, sync_will_start
+from aqt.qt import QTimer
+
 from .configuration import Config
-from .utils import *
 from .i18n import t
+from .schedule.disperse_siblings import disperse_siblings
+from .schedule.reschedule import reschedule
+from .utils import *
 
 
 def create_comparelog(local_rids: List[int]) -> None:
@@ -33,17 +36,22 @@ def review_cid_remote(local_rids: List[int]):
     return remote_reviewed_cids
 
 
-def auto_reschedule(local_rids: List[int], texts: List[str]):
-    if len(local_rids) == 0:
+def push_changes() -> None:
+    if not mw.pm.sync_auth():
         return
+    mw._sync_collection_and_media(mw._refresh_after_sync)
+
+
+def auto_reschedule(remote_reviewed_cids: List[int], texts: List[str]) -> bool:
+    if len(remote_reviewed_cids) == 0:
+        return False
     texts.clear()
     config = Config()
     config.load()
+    cnt = 0
     if not config.auto_reschedule_after_sync:
         texts.append(t("reschedule-skipped"))
-        return
-
-    remote_reviewed_cids = review_cid_remote(local_rids)
+        return False
 
     fut = reschedule(
         did=None,
@@ -55,26 +63,30 @@ def auto_reschedule(local_rids: List[int], texts: List[str]):
 
     if fut:
         # wait for reschedule to finish
-        texts.append(fut.result())
+        result = fut.result()
+        cnt, finish_text = result[0], result[1]
+        texts.append(finish_text)
+
+    return cnt > 0
 
 
-def auto_disperse(local_rids: List[int], texts: List[str]):
-    if len(local_rids) == 0:
-        return
+def auto_disperse(remote_reviewed_cids: List[int], texts: List[str]) -> bool:
+    if len(remote_reviewed_cids) == 0:
+        return False
     config = Config()
     config.load()
+    card_cnt = 0
     if not config.auto_disperse_after_sync:
-        return
+        return False
 
     if config.auto_reschedule_after_sync and config.auto_disperse_after_reschedule:
-        return
+        return False
 
-    remote_reviewed_cids = review_cid_remote(local_rids)
     remote_reviewed_cid_string = ids2str(remote_reviewed_cids)
     remote_reviewed_nids = [
         nid
-        for nid in mw.col.db.list(f"""SELECT DISTINCT nid 
-            FROM cards 
+        for nid in mw.col.db.list(f"""SELECT DISTINCT nid
+            FROM cards
             WHERE id IN {remote_reviewed_cid_string}
         """)
     ]
@@ -90,13 +102,21 @@ def auto_disperse(local_rids: List[int], texts: List[str]):
 
     if fut:
         # wait for disperse to finish
-        return fut.result()
+        card_cnt, _ = fut.result()
+
+    return card_cnt > 0
 
 
 def init_sync_hook():
     local_rids = []
     texts = []
 
+    def on_sync_finished():
+        remote_reviewed_cids = review_cid_remote(local_rids) if local_rids else []
+        modified = auto_reschedule(remote_reviewed_cids, texts)
+        modified = auto_disperse(remote_reviewed_cids, texts) or modified
+        if modified:
+            QTimer.singleShot(0, push_changes)
+
     sync_will_start.append(lambda: create_comparelog(local_rids))
-    sync_did_finish.append(lambda: auto_reschedule(local_rids, texts))
-    sync_did_finish.append(lambda: auto_disperse(local_rids, texts))
+    sync_did_finish.append(on_sync_finished)


### PR DESCRIPTION
Automatically push the auto-rescheduled and auto-dispersed cards to decrease the chances of sync conflicts when the same cards are reviewed on another device.

Fixes #648
Supersedes and closes #649

FYI @chrislongros