### PR TITLE
Fix: skip filtered-deck cards in post-sync autoreschedule/disperse

### DIFF
--- a/sync_hook.py
+++ b/sync_hook.py
@@ -25,13 +25,15 @@ def review_cid_remote(local_rids: List[int]):
     remote_reviewed_cids = [
         cid
         for cid in mw.col.db.list(
-            f"""SELECT DISTINCT cid
+            f"""SELECT DISTINCT revlog.cid
             FROM revlog
-            WHERE id NOT IN {local_rid_string}
-            {"AND type != 4" if config.auto_disperse_after_reschedule else "AND ease > 0"}
-            AND (type < 3 OR factor != 0)
+            JOIN cards ON cards.id = revlog.cid
+            WHERE revlog.id NOT IN {local_rid_string}
+            AND cards.odid = 0
+            {"AND revlog.type != 4" if config.auto_disperse_after_reschedule else "AND revlog.ease > 0"}
+            AND (revlog.type < 3 OR revlog.factor != 0)
             """
-        )  # type: 0=learn, 1=review, 2=relearn, 3=filtered, 4=manual, 5=reschedule
+        )  # revlog.type: 0=learn, 1=review, 2=relearn, 3=filtered, 4=manual, 5=reschedule
     ]
     return remote_reviewed_cids
 


### PR DESCRIPTION
Follow-up to #652.

If a card is in a filtered deck (`odid != 0`), the post-sync reschedule only updates its `odue` and the card stays in the filtered deck — but it still updates `mod`/`usn`. The end result is that reviews on other devices get overwritten.

Fix: skip cards that are in a filtered deck. The card keeps the schedule from its review and is rescheduled normally once it's back in its home deck.